### PR TITLE
FgFlex: concat attention outputs w/ correct task convolution outputs

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -2215,7 +2215,7 @@ class FgFlex(BertHead):
                 attn_logits = relation_components["linear"](attn_inter)  # produce logits for first_task using info from attn
 
                 # stack attention outputs for this relation (averaged after all stacks complete)
-                if first_task is not "shared":
+                if first_task not in ("shared", "all"):
                     outputs[first_task].append(attn_logits)
 
                 # append attn output to list if first task present, else create new list

--- a/src/model.py
+++ b/src/model.py
@@ -2141,12 +2141,10 @@ class FgFlex(BertHead):
         cnn_outputs = {"shared": shared_output}  # only the information learned from shared cnn(s), no embeddings
 
         for stack in range(stack_count):
-            print("stack"*10, stack)
             ######################################
             # Subtask CNN that mimic IMN setup
             ######################################
             for task in self.subtasks:
-                print(task*10)
                 task_output = task_inputs[task]
 
                 if split_cnn_tasks is not None and task in split_cnn_tasks: 
@@ -2159,8 +2157,6 @@ class FgFlex(BertHead):
                     )
                 elif len(self.components[task][f"cnn_{stack}"]) > 0:
                         
-                    print(self.components[task][f"cnn_{stack}"])
-                    print(task_output.shape)
                     cnn_outputs[task] = self.components[task][f"cnn_{stack}"](task_output)
                 else: 
                     cnn_outputs[task] = shared_output
@@ -2168,9 +2164,6 @@ class FgFlex(BertHead):
                 # cat embedding dim when task cnn exists (i.e. task_layers not 0)
                 task_output = torch.cat((embeddings, cnn_outputs[task]), dim=1)  
 
-                print(self.components[task][f"linear_{stack}"])
-                print(task_output.shape)
-                # BUG crashes when task_layers = 0 
                 outputs[task].append(self.components[task][f"linear_{stack}"](task_output.permute(0, 2, 1)))
 
             cnn_outputs["all"] = sum([cnn_outputs[task] for task in self.subtasks])


### PR DESCRIPTION
Realized that just adding tensors probably is erasing some of the information learned.
By concatenating all the information learned for a given task in a given stack, then re-encoding to the next stack's shape, we ensure all bits of information are maintained until the end of each stack. 

Another way of doing this would have been to expand the cnn_dim for each stack. 
While that probably would have an affect on results, I'll stick to re-encoding rn since others have used this before. 
This alternative can be a part of future work.