### PR TITLE
FgFlex: debug cnn dim and kernel size

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -1985,33 +1985,33 @@ class FgFlex(BertHead):
                     ## CNN component: three possible cnn types for subtasks
                     if expanding_cnn:  # Sometimesse will be 0, other times None
                         components[task][f"cnn_{stack}"] = torch.nn.Sequential(*[
-                            self.expanding_cnn_block(cnn_dim*2, cnn_dim, kernel_size, m=expanding_cnn)
+                            self.expanding_cnn_block((768+cnn_dim), cnn_dim, kernel_size, m=expanding_cnn)
                             for layer in range(task_layers)
                         ])
                     elif None not in (split_cnn_tasks, split_cnn_kernels): 
                         if task in split_cnn_tasks:
                             components[task][f"cnn_{stack}"] = self.split_cnn_block(
-                                cnn_dim*2, cnn_dim, split_cnn_kernels, task_layers
+                                (768+cnn_dim), cnn_dim, split_cnn_kernels, task_layers
                             )
                         else:
                             components[task][f"cnn_{stack}"] = torch.nn.Sequential(*[
-                                self.cnn_block(cnn_dim*2, cnn_dim, kernel_size)
+                                self.cnn_block((768+cnn_dim), cnn_dim, kernel_size)
                                 for layer in range(task_layers)
                             ])
                     else:
                         components[task][f"cnn_{stack}"] = torch.nn.Sequential(*[
-                            self.cnn_block(cnn_dim*2, cnn_dim, kernel_size)
+                            self.cnn_block((768+cnn_dim), cnn_dim, kernel_size)
                             for layer in range(task_layers)
                         ])
         
                     ## Feedforward component: Expands per stack due to concatentation
-                    components[task][f"linear_{stack}"] = self.linear_block(in_features=(cnn_dim*2), out_features=3)
+                    components[task][f"linear_{stack}"] = self.linear_block(in_features=((768+cnn_dim)), out_features=3)
 
         else: 
             for task in subtasks:
                 # final outputs for each task
                 # in_features are concats of embeddings, shared layers, and task cnns
-                components[task]["linear"] = self.linear_block(in_features=cnn_dim*2, out_features=3)
+                components[task]["linear"] = self.linear_block(in_features=(768+cnn_dim), out_features=3)
         ######################################
         # Shared relation components
         ######################################
@@ -2063,7 +2063,7 @@ class FgFlex(BertHead):
                     # map subtask information back to shared hidden state size after (multiple) attention(s)
                     components[rel[0]]["re_encode"] = self.linear_block(
                         in_features=cnn_dim*(1 + count),  # 1 task output + number of relations with rel[0] as first task
-                        out_features=cnn_dim*2
+                        out_features=(768+cnn_dim)
                     )
 
         components["relations"] = relations

--- a/src/model.py
+++ b/src/model.py
@@ -2227,11 +2227,6 @@ class FgFlex(BertHead):
             for task in relation_inters:
                 if task in self.subtasks:
                     all_task_inters = torch.cat([cnn_outputs[task].permute(0, 2, 1)] + relation_inters[task], dim=-1)
-                    print(cnn_outputs[task].permute(0, 2, 1).shape)
-                    print(relation_inters[task][0].shape)
-                    print(all_task_inters.shape)
-                    print(self.components[task]["re_encode"])
-                    print(task)
                     task_inputs[task] = self.components[task]["re_encode"](all_task_inters).permute(0, 2, 1)  # batch, sequence, embedding
 
 

--- a/src/model.py
+++ b/src/model.py
@@ -2048,14 +2048,13 @@ class FgFlex(BertHead):
         relations = torch.nn.ModuleDict({})
         attn_linears = torch.nn.ModuleDict({})
         for stack in range(stack_count):
+            relations[f"stack_{stack}"] = torch.nn.ModuleDict({})
             for rel in attention_relations:
-                relations[f"stack_{stack}"] = torch.nn.ModuleDict({
-                    f"{rel[0]}_at_{rel[1]}": torch.nn.ModuleDict({
-                        "attn": self.attn_block(cnn_dim),
+                relations[f"stack_{stack}"][f"{rel[0]}_at_{rel[1]}"] = torch.nn.ModuleDict({
+                    "attn": self.attn_block(cnn_dim),
 
-                        # new linear for each attn relation for first_task logits using attn information
-                        "linear": self.linear_block(cnn_dim*2, 3),
-                    })
+                    # new linear for each attn relation for first_task logits using attn information
+                    "linear": self.linear_block(cnn_dim*2, 3)
                 })
                 if rel[0] in self.subtasks + ["shared"] and "re_encode" not in components[rel[0]].keys():
                     # only reach this one time per first_task=rel[0]
@@ -2228,6 +2227,11 @@ class FgFlex(BertHead):
             for task in relation_inters:
                 if task in self.subtasks:
                     all_task_inters = torch.cat([cnn_outputs[task].permute(0, 2, 1)] + relation_inters[task], dim=-1)
+                    print(cnn_outputs[task].permute(0, 2, 1).shape)
+                    print(relation_inters[task][0].shape)
+                    print(all_task_inters.shape)
+                    print(self.components[task]["re_encode"])
+                    print(task)
                     task_inputs[task] = self.components[task]["re_encode"](all_task_inters).permute(0, 2, 1)  # batch, sequence, embedding
 
 


### PR DESCRIPTION
After last PR merge, jobs were queued. Most kept running, but both `cnn_dim` and `kernel_size` failed due to mismatching sizes.

This PR cleans up these bugs and checks different setups in notebook.
These jobs need to be queued up again, as well as `attn`, since that one will inevitably fail after first run